### PR TITLE
Fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Make sure you meet [the requirements for installing spatie/laravel-backup](https
 
 ## Installation
 
-First you must install [spatie/laravel-backup](https://docs.spatie.be/laravel-backup) into your Laravel app. The installation instructions are [here](https://docs.spatie.be/laravel-backup/v5/installation-and-setup). When successfull running `php artisan backup:create` on the terminal should create a backup and `php artisan backup:list` should return a list with an overview of all backup disks.
+First you must install [spatie/laravel-backup](https://docs.spatie.be/laravel-backup) into your Laravel app. The installation instructions are [here](https://docs.spatie.be/laravel-backup/v5/installation-and-setup). When successfull running `php artisan backup:run` on the terminal should create a backup and `php artisan backup:list` should return a list with an overview of all backup disks.
 
 You can install the nova tool in to a Laravel app that uses [Nova](https://nova.laravel.com) via composer:
 


### PR DESCRIPTION
Change `backup:create` to `backup:run`