### PR TITLE
Support for Laravel Backup v6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.1.0",
         "laravel/nova": "*",
-        "spatie/laravel-backup": "^5.10.0",
+        "spatie/laravel-backup": "^6.0",
         "symfony/process": "^4.1"
     },
     "require-dev": {

--- a/src/Http/Controllers/BackupStatusesController.php
+++ b/src/Http/Controllers/BackupStatusesController.php
@@ -20,7 +20,7 @@ class BackupStatusesController extends ApiController
                         'reachable' => $backupDestinationStatus->backupDestination()->isReachable(),
                         'healthy' => $backupDestinationStatus->isHealthy(),
                         'amount' => $backupDestinationStatus->backupDestination()->backups()->count(),
-                        'newest' => $backupDestinationStatus->backupDestination()->newestBackup()->date()
+                        'newest' => $backupDestinationStatus->backupDestination()->newestBackup()
                             ? $backupDestinationStatus->backupDestination()->newestBackup()->date()->diffForHumans()
                             : 'No backups present',
                         'usedStorage' => Format::humanReadableSize($backupDestinationStatus->backupDestination()->usedStorage()),

--- a/src/Http/Controllers/BackupStatusesController.php
+++ b/src/Http/Controllers/BackupStatusesController.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\BackupTool\Http\Controllers;
 
+use Spatie\Backup\Helpers\Format;
 use Illuminate\Support\Facades\Cache;
 use Spatie\Backup\Tasks\Monitor\BackupDestinationStatus;
 use Spatie\Backup\Tasks\Monitor\BackupDestinationStatusFactory;
@@ -11,18 +12,18 @@ class BackupStatusesController extends ApiController
     public function index()
     {
         return Cache::remember('backup-statuses', 1 / 15, function () {
-            return BackupDestinationStatusFactory::createForMonitorConfig(config('backup.monitorBackups'))
+            return BackupDestinationStatusFactory::createForMonitorConfig(config('backup.monitor_backups'))
                 ->map(function (BackupDestinationStatus $backupDestinationStatus) {
                     return [
-                        'name' => $backupDestinationStatus->backupName(),
-                        'disk' => $backupDestinationStatus->diskName(),
-                        'reachable' => $backupDestinationStatus->isReachable(),
+                        'name' => $backupDestinationStatus->backupDestination()->backupName(),
+                        'disk' => $backupDestinationStatus->backupDestination()->diskName(),
+                        'reachable' => $backupDestinationStatus->backupDestination()->isReachable(),
                         'healthy' => $backupDestinationStatus->isHealthy(),
-                        'amount' => $backupDestinationStatus->amountOfBackups(),
-                        'newest' => $backupDestinationStatus->dateOfNewestBackup()
-                            ? $backupDestinationStatus->dateOfNewestBackup()->diffForHumans()
+                        'amount' => $backupDestinationStatus->backupDestination()->backups()->count(),
+                        'newest' => $backupDestinationStatus->backupDestination()->newestBackup()->date()
+                            ? $backupDestinationStatus->backupDestination()->newestBackup()->date()->diffForHumans()
                             : 'No backups present',
-                        'usedStorage' => $backupDestinationStatus->humanReadableUsedStorage(),
+                        'usedStorage' => Format::humanReadableSize($backupDestinationStatus->backupDestination()->usedStorage()),
                     ];
                 })
                 ->values()


### PR DESCRIPTION
With the release of Laravel Backup v6 config keys have changed to snake case.
The `BackupDestinationStatus` class was also changed.

This PR makes changes to make this Nova tool compatible with v6.

This is a breaking change.
