### PR TITLE
Adds composer test command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,9 @@
             ]
         }
     },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
+    },
     "config": {
         "sort-packages": true
     },


### PR DESCRIPTION
The README states that you can run [composer test](https://github.com/spatie/nova-backup-tool/blob/master/README.md#L59) to run the tests.

However, this is not declared in `composer.json`.

This PR adds the `composer test` command.