### PR TITLE
Fix test

### DIFF
--- a/src/Http/Controllers/BackupsController.php
+++ b/src/Http/Controllers/BackupsController.php
@@ -51,7 +51,6 @@ class BackupsController extends ApiController
 
         $backupDestination
             ->backups()
-            ->dump()
             ->first(function (Backup $backup) use ($validated) {
                 return $backup->path() === $validated['path'];
             })

--- a/tests/Controllers/BackupsControllerTest.php
+++ b/tests/Controllers/BackupsControllerTest.php
@@ -46,9 +46,7 @@ class BackupsControllerTest extends TestCase
             ->postJson('/nova-vendor/spatie/backup-tool/backups', ['disk' => 'local'])
             ->assertSuccessful();
 
-        $pathToZip = 'Laravel/2018-01-01-00-00-00.zip';
-
-        Storage::disk('local')->assertExists($pathToZip);
+        Storage::disk('local')->assertExists('Laravel/2018-01-01-00-00-00.zip');
 
         $this
             ->deleteJson('/nova-vendor/spatie/backup-tool/backups', [
@@ -57,9 +55,7 @@ class BackupsControllerTest extends TestCase
             ])
             ->assertSuccessful();
 
-        $pathToZip = 'Laravel/2018-01-01-00-00-00.zip';
-
-        Storage::disk('local')->assertMissing($pathToZip);
+        Storage::disk('local')->assertMissing('Laravel/2018-01-01-00-00-00.zip');
     }
 
     /** @test */

--- a/tests/Controllers/BackupsControllerTest.php
+++ b/tests/Controllers/BackupsControllerTest.php
@@ -53,7 +53,7 @@ class BackupsControllerTest extends TestCase
         $this
             ->deleteJson('/nova-vendor/spatie/backup-tool/backups', [
                 'disk' => 'local',
-                'file' => 'Laravel/2018-01-01-00-00-00.zip',
+                'path' => 'Laravel/2018-01-01-00-00-00.zip',
             ])
             ->assertSuccessful();
 

--- a/tests/Controllers/BackupsControllerTest.php
+++ b/tests/Controllers/BackupsControllerTest.php
@@ -39,6 +39,7 @@ class BackupsControllerTest extends TestCase
             ->assertJsonStructure([0 => ['path', 'date', 'size']]);
     }
 
+    /** @test */
     public function it_can_delete_a_backup()
     {
         $this


### PR DESCRIPTION
The `it_can_delete_a_backup()` test was missing the `@test` annotation and therefore excluded from the tests.

This test was also failing because of a wrong paramater `file` instead of `path`.

I have also removed a `dump()` call in the `BackupsController` and cleaned up the test a bit by removing the (double) temporary `$pathToZip` variable. 