### PR TITLE
Removes symfony/process as a requirement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     "require": {
         "php": "^7.2",
         "laravel/nova": "*",
-        "spatie/laravel-backup": "^6.0",
-        "symfony/process": "^4.1"
+        "spatie/laravel-backup": "^6.0"
     },
     "require-dev": {
         "orchestra/testbench": "^3.6",


### PR DESCRIPTION
This packages requires the Symfony Process component although this component is not by this package.

This PR removes the requirement of `symfony/process`.