### PR TITLE
Use 4 seconds for cache TTL

### DIFF
--- a/src/Http/Controllers/BackupStatusesController.php
+++ b/src/Http/Controllers/BackupStatusesController.php
@@ -11,7 +11,7 @@ class BackupStatusesController extends ApiController
 {
     public function index()
     {
-        return Cache::remember('backup-statuses', now()->addMinutes(1 / 15), function () {
+        return Cache::remember('backup-statuses', now()->addSeconds(4), function () {
             return BackupDestinationStatusFactory::createForMonitorConfig(config('backup.monitor_backups'))
                 ->map(function (BackupDestinationStatus $backupDestinationStatus) {
                     return [

--- a/src/Http/Controllers/BackupsController.php
+++ b/src/Http/Controllers/BackupsController.php
@@ -21,7 +21,7 @@ class BackupsController extends ApiController
 
         $backupDestination = BackupDestination::create($validated['disk'], config('backup.backup.name'));
 
-        return Cache::remember("backups-{$validated['disk']}", now()->addMinutes(1 / 15), function () use ($backupDestination) {
+        return Cache::remember("backups-{$validated['disk']}", now()->addSeconds(4), function () use ($backupDestination) {
             return $backupDestination
                 ->backups()
                 ->map(function (Backup $backup) {


### PR DESCRIPTION
As Laravel 5.8 officially support Carbon 2 now, there is an issue with the cache TTL being used for the backup status. Carbon 2 no longer supports float values [1] for methods such as `addMinutes`, which this tool was using. This caused no cache to be used for the status endpoints.

This PR resolves the issue by using 4 seconds explicity as a cache TTL.

[1] https://github.com/briannesbitt/Carbon/blob/9e00bb73ff5c0825b12e8a465c9bc2aec8c3dcc0/src/Carbon/Carbon.php#L236