### PR TITLE
Fixing a breaking change introduced in v3.3.0

### DIFF
--- a/src/BackupToolServiceProvider.php
+++ b/src/BackupToolServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\BackupTool;
 
+use Laravel\Nova\Nova;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Spatie\BackupTool\Http\Middleware\Authorize;


### PR DESCRIPTION
Hello,

In v3.3.0 was introduced the following passage of code:

```php
Nova::translations(
      resource_path('lang/vendor/spatie/nova-backup-tool/'.app()->getLocale().'.json')
);
```

Unfortunately, that introduced the following error:
```
"Class 'Spatie\BackupTool\Nova' not found"
```

We needed to use the proper namespace:
```
use Laravel\Nova\Nova;
```

That fixes the problem for us!

Cheers!