### PR TITLE
Page not loading because of missing function sizeInBytes()

### DIFF
--- a/src/Http/Controllers/BackupsController.php
+++ b/src/Http/Controllers/BackupsController.php
@@ -28,7 +28,7 @@ class BackupsController extends ApiController
                     return [
                         'path' => $backup->path(),
                         'date' => $backup->date()->format('Y-m-d H:i:s'),
-                        'size' => Format::humanReadableSize($backup->sizeInBytes()),
+                        'size' => Format::humanReadableSize($backup->size()),
                     ];
                 })
                 ->toArray();

--- a/src/Http/Controllers/DownloadBackupController.php
+++ b/src/Http/Controllers/DownloadBackupController.php
@@ -39,7 +39,7 @@ class DownloadBackupController extends ApiController
         $downloadHeaders = [
             'Cache-Control' => 'must-revalidate, post-check=0, pre-check=0',
             'Content-Type' => 'application/zip',
-            'Content-Length' => $backup->sizeInBytes(),
+            'Content-Length' => $backup->size(),
             'Content-Disposition' => 'attachment; filename="'.$fileName.'"',
             'Pragma' => 'public',
         ];


### PR DESCRIPTION
The function `sizeInBytes()` doesn't exist anymore in the laravel-backup extension which caused some errors and the `backups` tab not loading in.