### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.0, 7.4]
+                php: [8.2, 8.0, 7.4]
                 laravel: [7.*, 8.*]
                 dependency-version: [prefer-stable]
                 include:
@@ -32,7 +32,7 @@ jobs:
 
             -   name: Install dependencies
                 run: |
-                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                    composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.63" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
                 env:
                     COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.2, 8.0, 7.4]
+                php: [8.2, 8.1, 8.0, 7.4]
                 laravel: [7.*, 8.*]
                 dependency-version: [prefer-stable]
                 include:
@@ -16,6 +16,11 @@ jobs:
                         testbench: 6.*
                     -   laravel: 7.*
                         testbench: 5.*
+                exclude:
+                    -   php: 8.2
+                        laravel: 7.*
+                    -   php: 8.1
+                        laravel: 7.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.0|^7.3",
         "illuminate/support": "^7.0|^8.0|^9.0",
         "laravel/nova": "^4.0",
-        "nesbot/carbon": "^2.31",
+        "nesbot/carbon": "^2.63",
         "spatie/laravel-backup": "^6.0|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary

This PR adds PHP 8.2 to the tests workflow.

It also bumps the required minimum version for nesbot/carbon.

_id:php82-support/v1.0_