### PR TITLE
added the new lang path present in the laravel 9.x and 10.x

### DIFF
--- a/src/BackupToolServiceProvider.php
+++ b/src/BackupToolServiceProvider.php
@@ -69,10 +69,12 @@ class BackupToolServiceProvider extends ServiceProvider
 
             Nova::translations(__DIR__.'/../resources/lang/'.$currentLocale.'.json');
             Nova::translations(resource_path('lang/vendor/nova-backup-tool/'.$currentLocale.'.json'));
+            Nova::translations(lang_path('vendor/nova-backup-tool/'.$currentLocale.'.json'));
         });
 
         $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'BackupTool');
         $this->loadJSONTranslationsFrom(__DIR__.'/../resources/lang');
         $this->loadJSONTranslationsFrom(resource_path('lang/vendor/nova-backup-tool'));
+        $this->loadJSONTranslationsFrom(lang_path('vendor/nova-backup-tool'));
     }
 }


### PR DESCRIPTION
Hi @freekmurze ,

In the newest Laravel versions, the default localization path is /lang not /resources/lang anymore, so with this PR the custom translation should be loaded without the need to create a new folder "lang" inside /resources (/resources/lang/vendor/nova-backup-tool).

Best Regards