### PR TITLE
fix issue with `spatie/laravel-backup` v9

### DIFF
--- a/src/Http/Controllers/BackupStatusesController.php
+++ b/src/Http/Controllers/BackupStatusesController.php
@@ -12,12 +12,7 @@ class BackupStatusesController extends ApiController
     public function index()
     {
         return Cache::remember('backup-statuses', now()->addSeconds(4), function () {
-            $monitorConfiguration = (new \ReflectionMethod(BackupDestinationStatusFactory::class, 'createForMonitorConfig'))
-                ->getParameters()[0]->getType()->getName() === 'Spatie\Backup\Config\MonitoredBackupsConfig'
-                ? \Spatie\Backup\Config\MonitoredBackupsConfig::fromArray(config('backup.monitor_backups'))
-                : config('backup.monitor_backups');
-
-            return BackupDestinationStatusFactory::createForMonitorConfig($monitorConfiguration)
+            return BackupDestinationStatusFactory::createForMonitorConfig($this->getMonitorConfig())
                 ->map(function (BackupDestinationStatus $backupDestinationStatus) {
                     return [
                         'name' => $backupDestinationStatus->backupDestination()->backupName(),
@@ -34,5 +29,21 @@ class BackupStatusesController extends ApiController
                 ->values()
                 ->toArray();
         });
+    }
+
+    /**
+     * Get monitor configuration data.
+     * spatie/laravel-backup ^9.x introduce DTO parameter instead of array.
+     *
+     * @return \Spatie\Backup\Config\MonitoredBackupsConfig|array
+     */
+    protected function getMonitorConfig()
+    {
+        $reflection = new \ReflectionMethod(BackupDestinationStatusFactory::class, 'createForMonitorConfig');
+        $monitorBackupsType = $reflection->getParameters()[0]->getType()->getName();
+
+        return $monitorBackupsType === 'Spatie\Backup\Config\MonitoredBackupsConfig'
+            ? \Spatie\Backup\Config\MonitoredBackupsConfig::fromArray(config('backup.monitor_backups'))
+            : config('backup.monitor_backups');
     }
 }


### PR DESCRIPTION
This PR fix issue with `spatie/laravel-backup` v9 who use DTO for `BackupDestinationStatusFactory::createForMonitorConfig` instead of array and allow usage of v9 with DTO, or ≤ v8 with array.

Error with `spatie/nova-backup-tool` v5.0.8 and `spatie/laravel-backup` v9 :

`local.ERROR: Spatie\Backup\Tasks\Monitor\BackupDestinationStatusFactory::createForMonitorConfig(): Argument #1 ($monitorConfiguration) must be of type Spatie\Backup\Config\MonitoredBackupsConfig, array given, called in /Users/tof/Herd/Nova/vendor/spatie/nova-backup-tool/src/Http/Controllers/BackupStatusesController.php on line 15 {"userId":1,"exception":"[object] (TypeError(code: 0): Spatie\\Backup\\Tasks\\Monitor\\BackupDestinationStatusFactory::createForMonitorConfig(): Argument #1 ($monitorConfiguration) must be of type Spatie\\Backup\\Config\\MonitoredBackupsConfig, array given, called in /Users/tof/Herd/Nova/vendor/spatie/nova-backup-tool/src/Http/Controllers/BackupStatusesController.php on line 15 at /Users/tof/Herd/Nova/vendor/spatie/laravel-backup/src/Tasks/Monitor/BackupDestinationStatusFactory.php:14)`