### PR TITLE
[6.x] Allow PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "illuminate/support": "^10.48.23|^11.35",
         "laravel/nova": "^5.0",
         "nesbot/carbon": "^2.62.1|^3.4",


### PR DESCRIPTION
Github Actions Workflows indicate, that PHP 8.1 is supported. This PR adjusts the composer.json constraint accordingly.

https://github.com/spatie/nova-backup-tool/blob/06c75eb211af9b0110fb18e2e3546e92696261ac/.github/workflows/run-tests.yml#L8-L18