### PR TITLE
Fix Github Actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,11 +11,11 @@ jobs:
                 php: [8.4, 8.3, 8.2, 8.1]
                 laravel: [11.*, 10.*]
                 dependency-version: [prefer-stable]
-            exclude:
-                -   php: 8.1
-                    laravel: 11.*
-                -   php: 8.4
-                    laravel: 10.*
+                exclude:
+                    -   php: 8.1
+                        laravel: 11.*
+                    -   php: 8.4
+                        laravel: 10.*
 
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,12 +8,10 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.4, 8.3, 8.2, 8.1]
+                php: [8.4, 8.3, 8.2]
                 laravel: [11.*, 10.*]
                 dependency-version: [prefer-stable]
                 exclude:
-                    -   php: 8.1
-                        laravel: 11.*
                     -   php: 8.4
                         laravel: 10.*
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "illuminate/support": "^10.48.23|^11.35",
         "laravel/nova": "^5.0",
         "nesbot/carbon": "^2.62.1|^3.4",


### PR DESCRIPTION
Github Actions Workflow is invalid. This PR fixes the syntax, so that tests are running again.
See: https://github.com/spatie/nova-backup-tool/actions/runs/12827959091

`exclude` should be formatted differently:
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixexclude

`spatie/laravel-backup` required PHP 8.2. Which did not see, because the tests were not running. Therefor reverting PHP 8.1 support.

Problems: Missing nova license for me, therefore composer dependencies are not getting installed. Not sure if tests are passing, as I have no Nova license.