### PR TITLE
fix Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/support": "^10.48.23|^11.35|^12.0|^13.0",
         "laravel/nova": "^5.0",
         "nesbot/carbon": "^2.62.1|^3.4",
-        "spatie/laravel-backup": "^9.0"
+        "spatie/laravel-backup": "^9.0|^10.0"
     },
     "require-dev": {
         "laravel/nova-devtool": "^1.4",


### PR DESCRIPTION
This pull request makes a small update to the `composer.json` file to expand the version constraint for the `spatie/laravel-backup` dependency, allowing compatibility with both version 9.x and 10.x _(only 10.x is compatible with Laravel 13)_.

- Dependency update:
  * Updated the `spatie/laravel-backup` version constraint in `composer.json` to support both `^9.0` and `^10.0`.